### PR TITLE
Add a bagde url to run IC-Light on OpenXLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or, to use background-conditioned demo:
 
 Model downloading is automatic.
 
-Note that the "gradio_demo.py" has an official [huggingFace Space here](https://huggingface.co/spaces/lllyasviel/IC-Light).
+Note that the "gradio_demo.py" has an official [huggingFace Space here](https://huggingface.co/spaces/lllyasviel/IC-Light) and [![Open in OpenXLab](https://cdn-static.openxlab.org.cn/app-center/openxlab_app.svg)](https://openxlab.org.cn/apps/detail/houshaowei/IC-Light).
 
 # Screenshot
 


### PR DESCRIPTION
Hi [@lllyasviel ](https://github.com/lllyasviel),
Great work on [IC-Light](https://github.com/lllyasviel/IC-Light)!
This pull request enables IC-Light to run on OpenXLab (https://openxlab.org.cn/apps/detail/houshaowei/IC-Light). OpenXLab is an open-source AI community in China with over 50,000 active developers.