### PR TITLE
Fix Compatibility Issues Between huggingface_hub, diffusers, and transformers Versioning

### DIFF
--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -430,4 +430,5 @@ with block:
     example_quick_subjects.click(lambda x: x[0], inputs=example_quick_subjects, outputs=prompt, show_progress=False, queue=False)
 
 
-block.launch(server_name='0.0.0.0')
+# block.launch(server_name='0.0.0.0')
+block.launch()

--- a/gradio_demo_bg.py
+++ b/gradio_demo_bg.py
@@ -462,4 +462,5 @@ with block:
     bg_gallery.select(bg_gallery_selected, inputs=bg_gallery, outputs=input_bg)
 
 
-block.launch(server_name='0.0.0.0')
+# block.launch(server_name='0.0.0.0')
+block.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 diffusers==0.27.2
-transformers==4.36.2
+transformers==4.30.2
 opencv-python
 safetensors
 pillow==10.2.0
 einops
 torch
-peft
+peft==0.3.0
 gradio==3.41.2
 protobuf==3.20
+huggingface_hub==0.25.2


### PR DESCRIPTION
This pull request addresses compatibility issues between the specified versions of the following libraries:

```
diffusers==0.27.2
transformers==4.30.2
huggingface_hub==0.25.2
peft==0.3.0
```

Additionally, it modifies the Gradio app launch configuration:

Changes the block.launch() command to use the default localhost instead of 0.0.0.0.
Comments out the server_name='0.0.0.0' configuration to ensure the app runs on the normal port (http://127.0.0.1:7860 or http://localhost:7860).
